### PR TITLE
SDL fixes for LG B7

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -1246,9 +1246,12 @@ static void SetVideoMode(void)
 
     // Force integer scales for resolution-independent rendering.
 
-#if SDL_VERSION_ATLEAST(2, 0, 5)
-    SDL_RenderSetIntegerScale(renderer, integer_scaling);
-#endif
+    SDL_version ver;
+    SDL_GetVersion(&ver);
+    if (SDL_VERSIONNUM(ver.major, ver.minor, ver.patch) >= 2005)
+    {
+        SDL_RenderSetIntegerScale(renderer, integer_scaling);
+    }
 
     // Blank out the full screen area in case there is any junk in
     // the borders that won't otherwise be overwritten.

--- a/src/i_video.c
+++ b/src/i_video.c
@@ -115,7 +115,7 @@ int window_height = SCREENHEIGHT_4_3 * 2;
 
 // Fullscreen mode, 0x0 for SDL_WINDOW_FULLSCREEN_DESKTOP.
 
-int fullscreen_width = 0, fullscreen_height = 0;
+int fullscreen_width = 1920, fullscreen_height = 1080;
 
 // Maximum number of pixels to use for intermediate scale buffer.
 


### PR DESCRIPTION
## Issue

I'm on LG B7 (3.9.0-62709), which has SDL 2.0.4.
The current build fails for me on the `SDL_RenderSetIntegerScale` as it's only available since SDL 2.0.5.
I'm also getting only a piece of the display (lower bottom left corner).

## Solution

1. Check for `2.0.5` at runtime instead of checking the compiled version.
2. Hardcode resolution to 1920x1080, which in turn sets `SDL_WINDOW_FULLSCREEN` for the window.

This fixes the issues for me and gets me a fully working DOOM.

## Notes

I don't think the solution is perfect, especially the hardcoded resolution, but maybe it's helpful to someone.